### PR TITLE
New upstream release: 7.2.0.4

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: libreoffice
-version: 7.2.0.2
+version: 7.2.0.4
 summary: LibreOffice is a free and open source office suite
 description: LibreOffice is a free and open source office suite, developed by The Document Foundation. The LibreOffice suite comprises programs for word processing, the creation and editing of spreadsheets, slideshows, diagrams and drawings, working with databases, and composing mathematical formulae.
 confinement: strict
@@ -37,7 +37,7 @@ parts:
             - gstreamer
             - yaru-icons
         plugin: autotools
-        source: http://download.documentfoundation.org/libreoffice/src/7.2.0/libreoffice-7.2.0.2.tar.xz
+        source: http://download.documentfoundation.org/libreoffice/src/7.2.0/libreoffice-7.2.0.4.tar.xz
         autotools-configure-parameters:
             - --disable-ccache
             - --disable-coinmp


### PR DESCRIPTION
# Pull Request Template

## Description

New upstream release: 7.2.0.4

## How Has This Been Tested?

Development happened over on launchpad directly: https://git.launchpad.net/~hellsworth/+git/libreoffice-snap/log/?h=7.2
This was to avoid the superfluous GH action build. I tested the resulting snaps locally.

**Test Configuration**:

* OS (please include version): Impish, Hirsute, Focal
* Any other relevant environment information: both wayland and xorg

Note that the font looks ugly on Impish only, on wayland only. Inkscape 1.1 has this problem too.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings

