### PR TITLE
Use system jpeg library (Fixes #5)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -59,6 +59,7 @@ parts:
             - --with-system-graphite
             - --with-system-harfbuzz
             - --with-system-icu
+            - --with-system-jpeg
             - --with-system-libexttextcat
             - --with-system-openldap
             - --with-system-nss


### PR DESCRIPTION
See https://forum.snapcraft.io/t/last-libreoffice-snap-7-2-0-4-not-able-to-import-jpeg/26450
Thanks to Rico Tzschichholz for helping root cause the problem!