### PR TITLE
HTTPS download

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -357,7 +357,7 @@ parts:
         source: https://github.com/ubuntu/libreoffice-style-yaru-fullcolor/archive/refs/tags/2021-09-01.tar.gz
         override-build: |
             set -eux
-            cd $SNAPCRAFT_PART_BUILD 
+            cd $SNAPCRAFT_PART_BUILD
             ./generate-oxt.sh
             if [ ! -f images_yaru.zip ]; then
                 echo "Yaru icons are missing!";

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -37,7 +37,7 @@ parts:
             - gstreamer
             - yaru-icons
         plugin: autotools
-        source: http://download.documentfoundation.org/libreoffice/src/7.2.3/libreoffice-7.2.3.1.tar.xz
+        source: https://download.documentfoundation.org/libreoffice/src/7.2.3/libreoffice-7.2.3.1.tar.xz
         autotools-configure-parameters:
             - --disable-ccache
             - --disable-coinmp


### PR DESCRIPTION
Use HTTPS to download the sources. The download server is redirecting to the closest mirror using HTTPS already so it's better to use HTTPS from the get go.