### PR TITLE
snapcraft: Add arm64 as a supported architecture

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -6,6 +6,11 @@ confinement: strict
 grade: stable
 base: core22
 compression: lzo
+architectures:
+  - build-on: amd64
+    run-on: amd64
+  - build-on: arm64
+    run-on: arm64
 
 passthrough:
   layout:


### PR DESCRIPTION
# Support Libreoffice on arm64

## Enable arm64 to build and run this Snap.

Since Libreoffice has been supporting arm64 for some time, enable the build to happen on and for arm64.

Fixes #27 (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- Build Libreoffice Snap on an M1 MacBook in a Ubuntu VM with lxd
- Install on Ubuntu Touch 20.04

**Test Configuration**:

* OS: Ubuntu (Touch) based on 20.04
* Any other relevant environment information: This was tested with a slightly patched version of `snapd` on Ubuntu Touch, enabling some AppArmor denials to pass more appropriately.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings

